### PR TITLE
Detect quasar-app-extension from package name

### DIFF
--- a/server/src/modes/template/tagProviders/index.ts
+++ b/server/src/modes/template/tagProviders/index.ts
@@ -83,7 +83,7 @@ export function getTagProviderSettings(packagePath: string | undefined) {
       dependencies['vuetify'] = true;
     }
     // Quasar v1+:
-    if (dependencies['quasar'] || devDependencies['quasar']) {
+    if (dependencies['quasar'] || devDependencies['quasar'] || rootPkgJson.name?.includes('quasar-app-extension-')) {
       settings['quasar'] = true;
     }
     // Quasar pre v1 on non quasar-cli:


### PR DESCRIPTION
app extensions does not have any dependencies by default.

Use `includes` instead of `startsWith` to support `@org/` in name.

See https://quasar.dev/app-extensions/introduction#app-extension-ext-id

<!-- Please follow https://github.com/vuejs/vetur/wiki/Pull-Request-Guidance -->